### PR TITLE
Update color scheme to brand palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#062A1F" />
     <meta
       name="description"
       content="Web site created using create-react-app"
@@ -15,6 +15,10 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Noto+Serif:wght@400&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#062A1F",
+  "background_color": "#FDF5E6"
 }

--- a/src/components/EditView.jsx
+++ b/src/components/EditView.jsx
@@ -178,7 +178,7 @@ const EditView = ({ onEditFile }) => {
                         aria-label="Edit file"
                         icon={<Edit />}
                         size="sm"
-                        colorScheme="green"
+                        colorScheme="success"
                         variant="ghost"
                         mr={2}
                         onClick={() => handleEditFile(file)}
@@ -187,7 +187,7 @@ const EditView = ({ onEditFile }) => {
                       aria-label="Update file"
                       icon={<Upload />}
                       size="sm"
-                      colorScheme="blue"
+                      colorScheme="brand"
                       variant="ghost"
                       mr={2}
                       isLoading={updateFileMutation.isLoading}
@@ -206,7 +206,7 @@ const EditView = ({ onEditFile }) => {
                       aria-label="Delete file"
                       icon={<Trash2 />}
                       size="sm"
-                      colorScheme="red"
+                      colorScheme="error"
                       variant="ghost"
                       onClick={() => handleDeleteFile(file)}
                       isLoading={deleteFileMutation.isLoading}
@@ -221,13 +221,13 @@ const EditView = ({ onEditFile }) => {
       <VStack width="40%" spacing={4} align="stretch">
         <Button
           leftIcon={<Download />}
-          colorScheme="teal"
+          colorScheme="brand"
           size="md"
           onClick={handleDownloadConfiguration}
         >
           Download Configuration
         </Button>
-        <Button leftIcon={<Upload />} colorScheme="purple" size="md" as="label">
+        <Button leftIcon={<Upload />} colorScheme="accent" size="md" as="label">
           Upload Configuration
           <input
             type="file"

--- a/src/components/PdfUploadView.jsx
+++ b/src/components/PdfUploadView.jsx
@@ -245,7 +245,7 @@ const PdfUploadView = () => {
                   <Text fontWeight="bold" mb={1}>Available links:</Text>
                   <VStack align="start" spacing={1}>
                     {Object.entries(response.gene_urls).map(([name, url]) => (
-                        <Link key={name} href={url} isExternal color="blue.500" textDecoration="underline">
+                        <Link key={name} href={url} isExternal color="brand.500" textDecoration="underline">
                           {name}
                         </Link>
                     ))}
@@ -488,14 +488,14 @@ const PdfUploadView = () => {
                 id="pdf-upload"
               />
               <label htmlFor="pdf-upload">
-                <Button as="span" leftIcon={<Upload />} colorScheme="blue">
+                <Button as="span" leftIcon={<Upload />} colorScheme="brand">
                   Select PDF
                 </Button>
               </label>
               {selectedFile && <Text mt={2}>{selectedFile.name}</Text>}
               <Button
                 ml={2}
-                colorScheme="green"
+                colorScheme="success"
                 onClick={handleUpload}
                 isLoading={uploadMutation.isPending}
                 isDisabled={!selectedFile}
@@ -546,8 +546,8 @@ const PdfUploadView = () => {
                 <Flex justify="space-between" align="center" mb={3}>
                   <Heading size="md">Patients in Document</Heading>
                   <Flex>
-                    <Button 
-                      colorScheme="green" 
+                    <Button
+                      colorScheme="success"
                       size="sm" 
                       mr={2}
                       leftIcon={<span role="img" aria-label="download">📊</span>}
@@ -616,7 +616,7 @@ const PdfUploadView = () => {
                                   {patient.family ? `Family ${patient.family} - Patient ${patient.patient}` : `Patient ${patient.patient}`}
                                 </Text>
                             </Box>
-                              <Badge colorScheme="blue" mr={2}>
+                              <Badge colorScheme="brand" mr={2}>
                                 {patient.family ? `Family ${patient.family}` : 'No Family'}
                               </Badge>
                               <PatientIdentifierEditModal
@@ -637,7 +637,7 @@ const PdfUploadView = () => {
                           <VStack align="start" spacing={4} width="100%">
                             {/* Display motor_symptoms with the existing format */}
                             <Box width="100%">
-                              <Heading size="sm" mb={2} color="blue.600">Motor Symptoms</Heading>
+                              <Heading size="sm" mb={2} color="brand.600">Motor Symptoms</Heading>
                               <Box p={3} borderWidth="1px" borderRadius="md" bg="gray.50">
                                     {(patientDetails.motor_symptoms || '').split(';').map((symptom, idx) => (
                                   <Text key={idx} mb={1}>
@@ -649,7 +649,7 @@ const PdfUploadView = () => {
 
                             {/* Display non_motor_symptoms with the existing format */}
                             <Box width="100%">
-                              <Heading size="sm" mb={2} color="green.600">Non-Motor Symptoms</Heading>
+                              <Heading size="sm" mb={2} color="success.500">Non-Motor Symptoms</Heading>
                               <Box p={3} borderWidth="1px" borderRadius="md" bg="gray.50">
                                     {(patientDetails.non_motor_symptoms || '').split(';').map((symptom, idx) => (
                                   <Text key={idx} mb={1}>
@@ -665,7 +665,7 @@ const PdfUploadView = () => {
                               key !== 'individual_id' && key !== 'family_id'
                             ).map(([key, value]) => (
                               <Box key={key} width="100%">
-                                <Heading size="sm" mb={2} color="purple.600">
+                                <Heading size="sm" mb={2} color="accent.500">
                                   {key.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
                                 </Heading>
                                 <Box p={3} borderWidth="1px" borderRadius="md" bg="gray.50">
@@ -744,7 +744,7 @@ const PdfUploadView = () => {
               }}
             />
             <Button
-              colorScheme="green"
+              colorScheme="success"
               isDisabled={!selectedZip || uploadingZip}
               onClick={handleZipUpload}
             >
@@ -760,7 +760,7 @@ const PdfUploadView = () => {
             )}
 
             {downloadReady && (
-              <Button colorScheme="blue" onClick={handleDownloadResults}>
+              <Button colorScheme="brand" onClick={handleDownloadResults}>
                 Download Results
               </Button>
             )}

--- a/src/providers/ChakraProvider.jsx
+++ b/src/providers/ChakraProvider.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { ChakraProvider as Chakra, ColorModeScript } from "@chakra-ui/react";
+import theme from "../theme";
 
 const ChakraProvider = ({ children }) => (
-  <Chakra resetCSS>
-    <ColorModeScript />
+  <Chakra resetCSS theme={theme}>
+    <ColorModeScript initialColorMode={theme.config?.initialColorMode} />
     {children}
   </Chakra>
 );

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,92 @@
+import { extendTheme } from "@chakra-ui/react";
+
+const colors = {
+  primary: "#062A1F",
+  secondary: "#BADAD3",
+  accent: "#D6C34E",
+  background: "#FDF5E6",
+  text: "#000000",
+  error: "#B00020",
+  success: "#2E7D32",
+  warning: "#F9A825",
+  info: "#0288D1",
+  link: "#062A1F",
+  disabled: "#A8A8A8",
+  border: "#E0E0E0",
+  shadow: "#A8A8A8",
+  hover: "#044336",
+  active: "#041F18",
+  focus: "#062A1F",
+  placeholder: "#A8A8A8",
+  selected: "#062A1F",
+  highlight: "#D6C34E",
+  divider: "#E0E0E0",
+  loading: "#062A1F",
+  successBg: "#E8F5E9",
+  errorBg: "#FFEBEE",
+  warningBg: "#FFF8E1",
+  infoBg: "#E1F5FE",
+  disabledBg: "#F5F5F5",
+  selectedBg: "#BADAD3",
+  highlightBg: "#FFF9C4",
+  dividerBg: "#E0E0E0",
+  loadingBg: "#FDF5E6",
+};
+
+const theme = extendTheme({
+  config: {
+    initialColorMode: "light",
+    useSystemColorMode: false,
+  },
+  fonts: {
+    heading: "'Noto Serif', serif",
+    body: "'Noto Sans', sans-serif",
+  },
+  colors: {
+    brand: {
+      50: colors.background,
+      100: colors.secondary,
+      200: colors.secondary,
+      300: colors.accent,
+      400: colors.accent,
+      500: colors.primary,
+      600: colors.hover,
+      700: colors.active,
+    },
+    success: { 500: colors.success },
+    error: { 500: colors.error },
+    warning: { 500: colors.warning },
+    info: { 500: colors.info },
+    accent: { 500: colors.accent },
+  },
+  styles: {
+    global: {
+      body: {
+        bg: colors.background,
+        color: colors.text,
+        fontFamily: "'Noto Sans', sans-serif",
+        fontWeight: 400,
+      },
+      a: {
+        color: colors.link,
+        _hover: { color: colors.hover },
+      },
+    },
+  },
+  components: {
+    Heading: {
+      baseStyle: {
+        fontFamily: "'Noto Serif', serif",
+        fontWeight: 400,
+      },
+    },
+    Button: {
+      baseStyle: {
+        fontFamily: "'Noto Sans', sans-serif",
+        fontWeight: 400,
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- implement custom Chakra UI theme with brand colors
- apply custom theme in `ChakraProvider`
- update manifest and HTML theme color values
- revise component color schemes to use new palette
- load Noto fonts and set heading/body fonts in theme

## Testing
- `npm test --silent` *(fails: react-scripts not found)*