### PR TITLE
Add comparison flag to gene export link

### DIFF
--- a/src/components/PdfUploadView.jsx
+++ b/src/components/PdfUploadView.jsx
@@ -504,7 +504,12 @@ const PdfUploadView = () => {
                   <AlertTitle>MDSGene Link Available</AlertTitle>
                   <AlertDescription>
                     You can access the exported data{' '}
-                    <Link href={geneUrl} isExternal color="brand.500" textDecoration="underline">
+                    <Link
+                      href={`${geneUrl}${geneUrl.includes('?') ? '&' : '?'}comparison=true`}
+                      isExternal
+                      color="brand.500"
+                      textDecoration="underline"
+                    >
                       here
                     </Link>
                     .


### PR DESCRIPTION
## Summary
- tweak export link so that it adds `comparison=true`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*